### PR TITLE
Fix svg path a

### DIFF
--- a/src/uc2/formats/svg/svglib.py
+++ b/src/uc2/formats/svg/svglib.py
@@ -342,10 +342,6 @@ def parse_svg_path_cmds(pathcmds):
 				l = libgeom.distance(*vector)
 
 				if l > 2.0 * r:
-					coeff = 2.0 * r / l
-					tr = [coeff, 0.0, 0.0, coeff, 0.0, 0.0]
-					dir_tr = libgeom.multiply_trafo(dir_tr, tr)
-					vector = libgeom.apply_trafo_to_points(vector, tr)
 					r = l / 2.0
 
 				mp = libgeom.midpoint(*vector)


### PR DESCRIPTION
if the ellipse is not big enough to reach from (x1, y1) to (x2, y2) then the ellipse is scaled up uniformly until there is exactly one solution. 
Sufficient to calculate the radius.
[paths-data-03-f_(Ma).svg.zip](https://github.com/sk1project/sk1-wx/files/614998/paths-data-03-f_.Ma.svg.zip)
