### PR TITLE
uniconvertor: Support GraphicsMagick

### DIFF
--- a/src/uc2/libimg/_libimg.c
+++ b/src/uc2/libimg/_libimg.c
@@ -17,12 +17,17 @@
  */
 
 #include <Python.h>
-#include <wand/MagickWand.h>
+#include <wand/magick_wand.h>
 
 static PyObject *
 im_InitMagick(PyObject *self, PyObject *args) {
+	const char *path = NULL;
+	PyObject *py_path = NULL;
+	if (PyArg_UnpackTuple(args, "path", 0, 1, &py_path)) {
+		path = PyString_AsString(py_path);
+	}
 
-	MagickWandGenesis();
+	InitializeMagick(path);
 
 	Py_INCREF(Py_None);
 	return Py_None;
@@ -30,8 +35,7 @@ im_InitMagick(PyObject *self, PyObject *args) {
 
 static PyObject *
 im_TerminateMagick(PyObject *self, PyObject *args) {
-
-	MagickWandTerminus();
+	DestroyMagick();
 
 	Py_INCREF(Py_None);
 	return Py_None;
@@ -54,7 +58,7 @@ im_LoadImage(PyObject *self, PyObject *args) {
 	void *magick_pointer;
 	MagickWand *magick_wand;
 	char *filepath = NULL;
-	MagickBooleanType status;
+	MagickBool status;
 
 	if (!PyArg_ParseTuple(args, "Os", &magick_pointer, &filepath)){
 		return Py_BuildValue("i", 0);
@@ -100,7 +104,7 @@ im_WriteImage(PyObject *self, PyObject *args) {
 	void *magick_pointer;
 	MagickWand *magick_wand;
 	char *filepath = NULL;
-	MagickBooleanType status;
+	MagickBool status;
 
 	if (!PyArg_ParseTuple(args, "Os", &magick_pointer, &filepath)){
 		return Py_BuildValue("i", 0);
@@ -176,7 +180,7 @@ im_NextImage(PyObject *self, PyObject *args) {
 
 	void *magick_pointer;
 	MagickWand *magick_wand;
-	MagickBooleanType status;
+	MagickBool status;
 
 	if (!PyArg_ParseTuple(args, "O", &magick_pointer)){
 		Py_INCREF(Py_None);
@@ -207,7 +211,6 @@ im_NextImage(PyObject *self, PyObject *args) {
 //	  ColorSeparationType,
 //	  ColorSeparationMatteType,
 //	  OptimizeType,
-//	  PaletteBilevelMatteType
 
 static PyObject *
 im_GetImageType(PyObject *self, PyObject *args) {
@@ -254,9 +257,6 @@ im_GetImageType(PyObject *self, PyObject *args) {
 	else if (img_type == OptimizeType){
 		return Py_BuildValue("s", "OptimizeType");
 	}
-	else if (img_type == PaletteBilevelMatteType){
-		return Py_BuildValue("s", "PaletteBilevelMatteType");
-	}
 	else {
 		return Py_BuildValue("s", "UndefinedType");
 	}
@@ -269,7 +269,6 @@ im_GetImageType(PyObject *self, PyObject *args) {
 //GRAYColorspace,
 //TransparentColorspace,
 //OHTAColorspace,
-//LabColorspace,
 //XYZColorspace,
 //YCbCrColorspace,
 //YCCColorspace,
@@ -278,15 +277,12 @@ im_GetImageType(PyObject *self, PyObject *args) {
 //YUVColorspace,
 //CMYKColorspace,
 //sRGBColorspace,
-//HSBColorspace,
 //HSLColorspace,
 //HWBColorspace,
 //Rec601LumaColorspace,
 //Rec601YCbCrColorspace,
 //Rec709LumaColorspace,
 //Rec709YCbCrColorspace,
-//LogColorspace,
-//CMYColorspace
 
 static PyObject *
 im_GetColorspace(PyObject *self, PyObject *args) {
@@ -315,9 +311,6 @@ im_GetColorspace(PyObject *self, PyObject *args) {
 	else if (cs == OHTAColorspace){
 		return Py_BuildValue("s", "OHTAColorspace");
 	}
-	else if (cs == LabColorspace){
-		return Py_BuildValue("s", "LabColorspace");
-	}
 	else if (cs == XYZColorspace){
 		return Py_BuildValue("s", "XYZColorspace");
 	}
@@ -342,9 +335,6 @@ im_GetColorspace(PyObject *self, PyObject *args) {
 	else if (cs == sRGBColorspace){
 		return Py_BuildValue("s", "sRGBColorspace");
 	}
-	else if (cs == HSBColorspace){
-		return Py_BuildValue("s", "HSBColorspace");
-	}
 	else if (cs == HSLColorspace){
 		return Py_BuildValue("s", "HSLColorspace");
 	}
@@ -362,12 +352,6 @@ im_GetColorspace(PyObject *self, PyObject *args) {
 	}
 	else if (cs == Rec709YCbCrColorspace){
 		return Py_BuildValue("s", "Rec709YCbCrColorspace");
-	}
-	else if (cs == LogColorspace){
-		return Py_BuildValue("s", "LogColorspace");
-	}
-	else if (cs == CMYColorspace){
-		return Py_BuildValue("s", "CMYColorspace");
 	}
 	else {
 		return Py_BuildValue("s", "UndefinedColorspace");


### PR DESCRIPTION
The attached patch make uniconvertor use GraphicsMagick [1] instead of ImageMagick. This is merely a preliminary first version of proper dual-GraphicsMagick/ImageMagick support, as modifications to the build-system and the code will be necessary to support both ImageMagick and GraphicsMagick at the same time, since the two are not entirely compatible with regards to the MagickWand library due to licensing issues [2].

[1]: http://www.graphicsmagick.org/
[2]: http://www.graphicsmagick.org/wand/wand.html