### PR TITLE
Build sk1 on Debian

### DIFF
--- a/src/wal/const.py
+++ b/src/wal/const.py
@@ -52,10 +52,13 @@ IS_UNITY = DESKTOP_NAME == 'Unity'
 def is_unity_16_04():
     if IS_GTK:
         if platform.dist()[1]:
-            ver = int(platform.dist()[1].split('.')[0])
-            dist = platform.dist()[0]
-            if dist == 'Ubuntu' and ver >= 16 and IS_UNITY:
-                return True
+            try:
+                ver = int(platform.dist()[1].split('.')[0])
+                dist = platform.dist()[0]
+                if dist == 'Ubuntu' and ver >= 16 and IS_UNITY:
+                    return True
+            except ValueError:
+                return False
     return False
 
 


### PR DESCRIPTION
When building on Debian, detecting whether we are building on unity 16.04
failed:

```
Traceback (most recent call last):
  File "setup-sk1.py", line 48, in <module>
    from sk1 import appconst
  File "/home/aengelen/dev/sk1-wx/src/sk1/__init__.py
", line 20, in <module>
    from sk1.app_conf import get_app_config
  File "/home/aengelen/dev/sk1-wx/src/sk1/app_conf.py
", line 21, in <module>
    import wal
  File "/home/aengelen/dev/sk1-wx/src/wal/__init__.py
", line 18, in <module>
    from listwidgets import SimpleList, ReportList
  File "/home/aengelen/dev/sk1-wx/src/wal/listwidgets
.py", line 23, in <module>
    import const
  File "/home/aengelen/dev/sk1-wx/src/wal/const.py", line 62, in <module>
    IS_UNITY_16 = is_unity_16_04()
  File "/home/aengelen/dev/sk1-wx/src/wal/const.py", line 55, in is_unity_16_04
    ver = int(platform.dist()[1].split('.')[0])
ValueError: invalid literal for int() with base 10: 'buster/sid'
```

This patch makes the build system assume it is not on unity 16.04 when it fails
to parse the version